### PR TITLE
TDL-23202 Bump urllib3 for SCA

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os.path import abspath, dirname, join
 
 setup(
     name="tap-nice-incontact",
-    version="0.3.0",
+    version="0.3.1",
     description="Singer.io tap for extracting data from the NICE InContact Reporting API",
     author="Stitch",
     url="http://singer.io",

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         "simplejson==3.11.1",
         "singer-python==5.12.1",
         "six==1.15.0",
-        "urllib3==1.26.6",
+        "urllib3==1.26.18",
         "isodate==0.6.0",
     ],
     entry_points="""


### PR DESCRIPTION
# Description of change
Moves urllib3 to a version that is not affected by [GHSA-g4mx-q9vg-27p4](https://github.com/advisories/GHSA-g4mx-q9vg-27p4)

# Manual QA steps
 - N/A
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
